### PR TITLE
Update organization references to opencadc-metadata-curation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update --no-install-recommends && apt-get dist-upgrade -y && \
     rm -rf /var/lib/apt/lists/ /tmp/* /var/tmp/*
 
 ARG OPENCADC_BRANCH=main
-ARG OPENCADC_REPO=opencadc
+ARG OPENCADC_REPO=opencadc-metadata-curation
 
 WORKDIR /usr/src/app
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ In an empty directory:
 1. `config.yml` is configuration information for the ingestion. It will work with
 the files named and described here. For a complete description of its
 content, see
-https://github.com/opencadc/collection2caom2/wiki/config.yml.
+https://github.com/opencadc-metadata-curation/collection2caom2/wiki/config.yml.
 
 1. The ways to tell this tool the work to be done:
 
@@ -77,5 +77,5 @@ proxy certificate as follows. You will be prompted for the password for your CAD
    ```
 
 1. For some instructions that might be helpful on using containers, see:
-https://github.com/opencadc/collection2caom2/wiki/Docker-and-Collections
+https://github.com/opencadc-metadata-curation/collection2caom2/wiki/Docker-and-Collections
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ In an empty directory:
 `docker-entrypoint.sh`, and `config.yml`. Copy these files to the working directory.
 
    ```
-   wget https://raw.github.com/opencadc/wallaby2caom2/main/Dockerfile
-   wget https://raw.github.com/opencadc/wallaby2caom2/main/scripts/docker-entrypoint.sh
-   wget https://raw.github.com/opencadc/wallaby2caom2/main/config/config.yml
+   wget https://raw.github.com/opencadc-metadata-curation/wallaby2caom2/main/Dockerfile
+   wget https://raw.github.com/opencadc-metadata-curation/wallaby2caom2/main/scripts/docker-entrypoint.sh
+   wget https://raw.github.com/opencadc-metadata-curation/wallaby2caom2/main/config/config.yml
    ```
 
 1. Make `docker-entrypoint.sh` executable.
@@ -68,7 +68,7 @@ proxy certificate as follows. You will be prompted for the password for your CAD
 1. To edit and test the application from inside a container:
 
    ```
-   user@dockerhost:<cwd># git clone https://github.com/opencadc/wallaby2caom2.git
+   user@dockerhost:<cwd># git clone https://github.com/opencadc-metadata-curation/wallaby2caom2.git
    user@dockerhost:<cwd># docker run --rm -ti -v <cwd>:/usr/src/app --user $(id -u):$(id -g) -e HOME=/usr/src/app --name wallaby_run_cli wallaby_run_cli /bin/bash
    root@53bef30d8af3:/usr/src/app# pip install -e ./wallaby2caom2
    root@53bef30d8af3:/usr/src/app# pip install mock pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ author_email = cadc@nrc-cnrc.gc.ca
 license = AGPLv3
 url = TBD
 edit_on_github = False
-github_project = opencadc/wallaby2caom2
+github_project = opencadc-metadata-curation/wallaby2caom2
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.3.2
 install_requires =


### PR DESCRIPTION
This PR updates all references from `opencadc` to `opencadc-metadata-curation` following the repository transfer.

## Changes
- Updated Dockerfile dependencies and base images\n- Updated README documentation\n- Updated shell scripts\n
## Files Modified
```
Dockerfile
README.md
scripts/wallaby_run.sh
scripts/wallaby_run_remote.sh
```

## Related
- Repository migration to opencadc-metadata-curation organization
- Ensures all references point to the correct organization

## Testing
- Verify builds pass
- Verify all references are updated correctly
